### PR TITLE
docs: add profile images of organizers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,9 @@ _site
 .sass-cache
 .jekyll-cache
 .jekyll-metadata
+.bundle
+.DS_Store
+Thumbs.db
+.idea
+.vscode
 vendor

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,8 +10,12 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
+    ffi (1.17.0-arm64-darwin)
     ffi (1.17.0-x64-mingw-ucrt)
     forwardable-extended (2.6.0)
+    google-protobuf (4.28.2-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
     google-protobuf (4.28.2-x64-mingw-ucrt)
       bigdecimal
       rake (>= 13)
@@ -65,6 +69,8 @@ GEM
     rexml (3.3.8)
     rouge (4.4.0)
     safe_yaml (1.0.5)
+    sass-embedded (1.79.4-arm64-darwin)
+      google-protobuf (~> 4.27)
     sass-embedded (1.79.4-x64-mingw-ucrt)
       google-protobuf (~> 4.27)
     terminal-table (3.0.2)
@@ -78,6 +84,7 @@ GEM
     webrick (1.8.2)
 
 PLATFORMS
+  arm64-darwin-24
   x64-mingw-ucrt
 
 DEPENDENCIES

--- a/organizers.html
+++ b/organizers.html
@@ -42,8 +42,11 @@
             <div class="chairs-category">
                 <h3>General Chairs</h3>
                 <div class="chairs">
+                    <img src="http://arrc.kaist.ac.kr/new_arrc/wp-content/uploads/2018/03/wtwoo-200x200.png" width="200px">
                     <p>Woontack Woo, KAIST</p>
+                    <img src="https://mr.hanyang.ac.kr/storage/images/e04bb551cd0bbab834bef460699427bc.png" width="200px">
                     <p>Joing-il Park, Hanyang University</p>
+                    <img src="http://empathiccomputing.org/wp-content/uploads/2018/05/Arindam2-570x570.png" width="200px">
                     <p>Arindam Dey, Meta</p>
                 </div>
             </div>
@@ -53,8 +56,11 @@
             <div class="chairs-category">
                 <h3>Poster Chairs</h3>
                 <div class="chairs">
+                    <img src="https://byungkukseo.github.io/cv/assets/pic/bkseo.jpeg" width="200px">
                     <p>Byung-Kuk Seo, ETRI</p>
+                    <img src="https://www.kennesaw.edu/ccse/academics/software-engineering-and-game-development/images/sungchul-jung.png" width="200px">
                     <p>Sungchul Jung, Kennesaw State University</p>
+                    <img src="https://images.squarespace-cdn.com/content/v1/620a1a08ff4ac21c6ac5151c/573419ad-2c94-468a-8780-c65610ed9608/Florian.jpg?format=750w" width="200px">
                     <p>Florian Weidner, Lancaster University</p>
 
                 </div>
@@ -65,7 +71,9 @@
             <div class="chairs-category">
                 <h3>Panel & Special Session Chairs</h3>
                 <div class="chairs">
+                    <img src="https://ce.mokpo.ac.kr/sites/ce/atchmnfl/profl/258/temp_1675062800002100.jpg" width="200px">
                     <p>Youngho Lee, Mokpo National University</p>
+                    <img src="https://api.research.unsw.edu.au/sites/default/files/images/profile/june_kim.jpg" width="200px">
                     <p>June Kim, The University of New South Wales</p>
                 </div>
             </div>
@@ -75,7 +83,9 @@
             <div class="chairs-category">
                 <h3>Publication Chairs</h3>
                 <div class="chairs">
+                    <img src="https://scholar.googleusercontent.com/citations?view_op=medium_photo&user=3nty_dwAAAAJ&citpid=2" width="200px">
                     <p>Dongsik Jo, University of Ulsan</p>
+                    <img src="http://efml.kaist.ac.kr/professor_files/syk_2020.jpg" width="200px">
                     <p>Sungyong Kim, KAIST</p>
                 </div>
             </div>
@@ -85,7 +95,9 @@
             <div class="chairs-category">
                 <h3>Finance Chairs</h3>
                 <div class="chairs">
+                    <img src="https://lh5.googleusercontent.com/BwAZ7cMiwEpYLMcZCQ-HaeAlDENWCBG22dlVY1JnKrxmxA-9GnB_jQkk5wiW8UsO32QEyHcAgf17l-mV1WV0RCJYBcv2FniyxznDVUSxKDHkbwIZOM7LF7XtRNE7sAiz7Q=w1280" width="200px">
                     <p>Seungwon Jeong, KAIST</p>
+                    <img src="https://hcitech.org/img/Member/Sang.jpg" width="200px">
                     <p>Sangho Yoon, KAIST</p>
                 </div>
             </div>
@@ -95,7 +107,9 @@
             <div class="chairs-category">
                 <h3>Web Chairs</h3>
                 <div class="chairs">
+                    <img src="https://scholar.googleusercontent.com/citations?view_op=medium_photo&user=epOZdMsAAAAJ&citpid=3" width="200px">
                     <p>Seungwon Kim, Chonnam National University</p>
+                    <img src="https://www.sustech.edu.cn/uploads/medium/2022/07/05100122_81346.jpg" width="200px">
                     <p>Seungwoo Je, SUSTech</p>
                 </div>
             </div>
@@ -105,7 +119,9 @@
             <div class="chairs-category">
                 <h3>Design Chairs</h3>
                 <div class="chairs">
+                    <img src="https://hicoda.hongik.ac.kr/wp-content/uploads/2022/01/%EC%9D%B4%EB%AF%B8%EC%A7%800_0001s_0009_Layer-2-copy.jpg" width="200px">
                     <p>Sunghee Ahn, Hongik University</p>
+                    <img src="https://scholar.googleusercontent.com/citations?view_op=medium_photo&user=U6_SdvMAAAAJ&citpid=18" width="200px">
                     <p>You-Jin Kim, Texas A&M</p>
                 </div>
             </div>
@@ -115,8 +131,11 @@
             <div class="chairs-category">
                 <h3>Publicity, SNS & Communications Chairs</h3>
                 <div class="chairs">
+                    <img src="https://scholar.googleusercontent.com/citations?view_op=medium_photo&user=PYVvxUUAAAAJ&citpid=2" width="200px">
                     <p>Yoosoo Oh, Daegu University</p>
+                    <img src="https://www.singaporetech.edu.sg/directory/sites/directory/files/styles/profile_picture/public/profile-picture/Dr%20Frank%20Guan.jpg?itok=sddwTxR7" width="200px">
                     <p>Frank Guan, Singapore Institute of Technology</p>
+                    <img src="https://scholar.googleusercontent.com/citations?view_op=medium_photo&user=mug2Xl4AAAAJ&citpid=2" width="200px">
                     <p>Xinyi Fu, Tsinghua University</p>
                 </div>
             </div>
@@ -126,7 +145,9 @@
             <div class="chairs-category">
                 <h3>Doctoral Consortium Chairs</h3>
                 <div class="chairs">
+                    <img src="https://lh4.googleusercontent.com/jz5XBCgRm-r09VWD_3_KVxHF2DgPfeuJJsUcu7_dt7G1Q1u1Ioxwz2p4JgXUc3B1Yu9q6g65_3HaRlky0dQZb-6-rmUO19EvI3LiUu6vyANw72HPnSQC8fRjKCuQ3Yw3=w1280" width="200px">
                     <p>Youngwon Kim, KIT</p>
+                    <img src="https://www.unlv.edu/sites/default/files/styles/450_width/public/employee_images/SiJungKim.jpg?itok=nMjUOh_f" width="200px">
                     <p>Si-jung Kim, University of Nevada Las Vegas</p>
                 </div>
             </div>
@@ -136,8 +157,11 @@
             <div class="chairs-category">
                 <h3>Workshop Chairs</h3>
                 <div class="chairs">
+                    <img src="https://sejong.elsevierpure.com/files-asset/11406957/614707.JPG?w=320&f=webp" width="200px">
                     <p>Jong Weon Lee, Sejong University</p>
+                    <img src="https://lh3.googleusercontent.com/APn74hyeBZAalMFPKYAVneWL5TaloWmNGsbLyyodKJLeKPi3JBc3AqkikDI6JRKp2MYGAo6D6EPrcE5S2vZVGCURanqQW0Me7SGYBSLQE1D3D4FnNnL9Uba_stqlvSSpJQ=w1280" width="200px">
                     <p>Hyungil Kim, University of Illinois Chicago</p>
+                    <img src="https://www.callumparker.com/img/resized1.jpg" width="200px">
                     <p>Callum Parker, University of Sydney</p>
                 </div>
             </div>
@@ -147,8 +171,10 @@
             <div class="chairs-category">
                 <h3>Tutorial Chairs</h3>
                 <div class="chairs">
+                    <img src="https://cse.pusan.ac.kr/sites/cse/atchmnfl/pnuProfl/455/temp_1598494071568100.jpg" width="200px">
                     <p>Myungho Lee, Pusan National University</p>
-                    <p>Grace Ahn, University of Georgia</p>
+                    <img src="https://scholar.googleusercontent.com/citations?view_op=medium_photo&user=A7xzcncAAAAJ&citpid=2" width="200px">
+                    <p>Sun Joo (Grace) Ahn, University of Georgia</p>
                 </div>
             </div>
         
@@ -157,7 +183,9 @@
             <div class="chairs-category">
                 <h3>Demonstrations Chairs</h3>
                 <div class="chairs">
+                    <img src="https://creative.sogang.ac.kr/wp-content/uploads/2024/02/prof_%EC%B5%9C%EC%9A%A9%EC%88%9C%EA%B5%90%EC%88%98%EB%8B%98-scaled.jpg" width="200px">
                     <p>Yongsoon Choi, Seogang University</p>
+                    <img src="https://profiles.utdallas.edu/storage/media/3896/conversions/jin-medium.jpg" width="200px">
                     <p>Jin Ryong Kim, The University of Texas at Dallas</p>
                 </div>
             </div>
@@ -167,9 +195,13 @@
             <div class="chairs-category">
                 <h3>Industrial Exhibition & Sponsorship Chairs</h3>
                 <div class="chairs">
+                    <img src="https://culture.jnu.ac.kr/upload/profInfo/11568080841287_1.png" width="200px">
                     <p>Choonsung Shin, Chonnam National University</p>
+                    <img src="https://media.licdn.com/dms/image/v2/C4D03AQFHaFDUWxEgDg/profile-displayphoto-shrink_100_100/profile-displayphoto-shrink_100_100/0/1517243346697?e=2147483647&v=beta&t=5ikGGo_laYHU0lSNEuWxBFdYz1PZBuNZEliyHQBC_Po" width="200px">
                     <p>Kwang-Soon Choi, KETI</p>
+                    <img src="https://media.licdn.com/dms/image/v2/D5603AQENHnnIYmo_OQ/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1695439211151?e=2147483647&v=beta&t=SnjFcMdUYYhiOOv2BzRbu7zaoyOl7YO2mBerGf-_-rs" width="200px">
                     <p>Wonki Hong, KEA</p>
+                    <img src="https://media.licdn.com/dms/image/v2/C5603AQH0ywjPNbwNKA/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1614653668114?e=2147483647&v=beta&t=gFIv770NdRkjI-CAihFkJGndRbdqzEpHHkxWz7SQfKg" width="200px">
                     <p>Il Yeo, Apple</p>
                 </div>
             </div>
@@ -179,7 +211,9 @@
             <div class="chairs-category">
                 <h3>Diversity, Equity, Inclusion, and Accessibility Chairs</h3>
                 <div class="chairs">
+                    <img src="https://lh3.googleusercontent.com/7Uu9paoiJIiSfTNE8F003XT62UrFITWY-ArVHwPz551mxFYfm8-gJwawqE7CNJkdwvNuiA=w1280" width="200px">
                     <p>Ahyoung Choi, Gachon University</p>
+                    <img src="https://www.sydney.edu.au/AcademicProfiles/profile/resource?urlid=soojeong.yoo" width="200px">
                     <p>Soojeong Yoo, University of Sydney</p>
                 </div>
             </div>
@@ -189,10 +223,15 @@
             <div class="chairs-category">
                 <h3>Local Arrangements Chairs</h3>
                 <div class="chairs">
+                    <img src="https://www.etri.re.kr/webzine/20221230/img/sub02_01.jpg" width="200px">
                     <p>Il Kwon Jeong, ETRI</p>
+                    <img src="https://media.licdn.com/dms/image/v2/C4D03AQF75fNm7-K-Ow/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1653634543003?e=2147483647&v=beta&t=u6dottbyQzs0PP8KULvKsOEObpfX5k_Z7YyESjRpisc" width="200px">
                     <p>Kisuk Lee, ETRI</p>
+                    <img src="https://pure.kaist.ac.kr/files-asset/7161829/2369.png?w=320&f=webp" width="200px">
                     <p>Seung Hyun Cha, KAIST</p>
+                    <img src="http://vcl.kaist.ac.kr/wp-content/uploads/2023/11/professor-1-2.png?w=135" width="200px">
                     <p>Jeongmi Kim, KAIST</p>
+                    <img src="https://csrc.kist.re.kr/data/file/m02_02/thumb-2709132887_nezSbEPY_40a789f8a13c92aab10905fcf4dcfb3495066d8d_1440x810.jpg" width="200px">
                     <p>Jeonghoon Lee, KISTI</p>
                 </div>
             </div>
@@ -202,8 +241,13 @@
             <div class="chairs-category">
                 <h3>Social Event Chairs</h3>
                 <div class="chairs">
+                    <!-- Dooyoung Kang's profile image is hard to find. Instead, I found Dooyoung Kim's profile image, which I will look at again later. -->
+                    <img src="https://dummyimage.com/200x200/999999/fff" width="200px"> <!-- Dooyoung Kang's profile -->
+                    <img src="https://uvrlab.org/static/img/members/KimDooYoung2.jpg" width="200px"> <!-- Dooyoung Kim's profile -->
                     <p>Dooyoung Kang, KAIST</p>
+                    <img src="http://arrc.kaist.ac.kr/new_arrc/wp-content/uploads/2024/07/BoramYoon.png" width="200px">
                     <p>Boram Yoon, KAIST</p>
+                    <img src="https://empathiccomputing.org/wp-content/uploads/2019/01/198A7901e.jpg" width="200px">
                     <p>Hyunjin Lee, KAIST</p>
                 </div>
             </div>
@@ -213,8 +257,11 @@
             <div class="chairs-category">
                 <h3>Student Volunteer Chairs</h3>
                 <div class="chairs">
+                    <img src="https://uvrlab.org/static/img/members/SeoYoungKang.jpg" width="200px">
                     <p>Seoyoung Kang, KAIST</p>
+                    <img src="https://uvrlab.org/static/img/members/jy_2.jpg" width="200px">
                     <p>Juyoung Lee, KAIST</p>
+                    <img src="https://media.licdn.com/dms/image/v2/D5603AQENXrBAAICV5g/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1710792106777?e=2147483647&v=beta&t=DX2P40bVO4fF3y6DqFSvMhbD7hU_-XabP38EkBj8OEw" width="200px">
                     <p>Hyeongil Nam, University of Calgary</p>
                 </div>
             </div>


### PR DESCRIPTION
TODO:
- Refactor Documents using Liquid syntax, if possible
- Search for the profile image of "Dooyoung Kang, KAIST" again
- Refactor by storing images directly on the blog instead of using web image links, if possible